### PR TITLE
Remove numeric check for GetCpuPercentage

### DIFF
--- a/NZBDash.Core.Test/WindowsHardwareServiceTests.cs
+++ b/NZBDash.Core.Test/WindowsHardwareServiceTests.cs
@@ -83,7 +83,6 @@ namespace NZBDash.Core.Test
             var process = Service.GetCpuPercentage();
 
             Assert.That(process, Is.Not.Null);
-            Assert.That(process, Is.GreaterThan(-1));
         }
 
         [Test]


### PR DESCRIPTION
The test now only asserts that the value for CPU percentage is
non-null. The actual value does not matter. #32 
